### PR TITLE
zephyr: do not check for rtt mutex

### DIFF
--- a/kernelports/Zephyr/trcKernelPort.c
+++ b/kernelports/Zephyr/trcKernelPort.c
@@ -837,13 +837,6 @@ void sys_trace_k_sem_reset(struct k_sem *sem) {
 
 /* Mutex trace function definitions */
 void sys_trace_k_mutex_init(struct k_mutex *mutex, int ret) {
-#if defined(CONFIG_PERCEPIO_RECORDER_TRC_RECORDER_STREAM_PORT_RTT) && !defined(PERCEPIO_RECORDER_TRC_STREAM_PORT_USE_INTERNAL_BUFFER)
-	/* If we use Zephyr RTT we have to ignore tracing of their locking
-	 * mutex or we will end up in a recursive trace loop
-	 */
-	if (mutex == &rtt_term_mutex) return;
-#endif
-
 	xTraceSDKEventBegin(PSF_EVENT_MUTEX_CREATE, 8);
 	xTraceSDKEventAddObject((void*)mutex);
 	xTraceSDKEventAdd32(ret);
@@ -854,13 +847,6 @@ void sys_trace_k_mutex_lock_enter(struct k_mutex *mutex, k_timeout_t timeout) {
 }
 
 void sys_trace_k_mutex_lock_blocking(struct k_mutex *mutex, k_timeout_t timeout) {
-#if defined(CONFIG_PERCEPIO_RECORDER_TRC_RECORDER_STREAM_PORT_RTT) && !defined(PERCEPIO_RECORDER_TRC_STREAM_PORT_USE_INTERNAL_BUFFER)
-	/* If we use Zephyr RTT we have to ignore tracing of their locking
-	 * mutex or we will end up in a recursive trace loop
-	 */
-	if (mutex == &rtt_term_mutex) return;
-#endif
-
 	xTraceSDKEventBegin(PSF_EVENT_MUTEX_TAKE_BLOCK, 8);
 	xTraceSDKEventAddObject((void*)mutex);
 	xTraceSDKEventAdd32(timeout.ticks);
@@ -868,13 +854,6 @@ void sys_trace_k_mutex_lock_blocking(struct k_mutex *mutex, k_timeout_t timeout)
 }
 
 void sys_trace_k_mutex_lock_exit(struct k_mutex *mutex, k_timeout_t timeout, int ret) {
-#if defined(CONFIG_PERCEPIO_RECORDER_TRC_RECORDER_STREAM_PORT_RTT) && !defined(PERCEPIO_RECORDER_TRC_STREAM_PORT_USE_INTERNAL_BUFFER)
-	/* If we use Zephyr RTT we have to ignore tracing of their locking
-	 * mutex or we will end up in a recursive trace loop
-	 */
-	if (mutex == &rtt_term_mutex) return;
-#endif
-
 	if (ret == 0) {
 		xTraceSDKEventBegin(PSF_EVENT_MUTEX_TAKE, 12);
 	} else {
@@ -891,13 +870,6 @@ void sys_trace_k_mutex_unlock_enter(struct k_mutex *mutex) {
 }
 
 void sys_trace_k_mutex_unlock_exit(struct k_mutex *mutex, int ret) {
-#if defined(CONFIG_PERCEPIO_RECORDER_TRC_RECORDER_STREAM_PORT_RTT) && !defined(PERCEPIO_RECORDER_TRC_STREAM_PORT_USE_INTERNAL_BUFFER)
-	/* If we use Zephyr RTT we have to ignore tracing of their locking
-	 * mutex or we will end up in a recursive trace loop
-	 */
-	if (mutex == &rtt_term_mutex) return;
-#endif
-
 	if (ret == 0) {
 		xTraceSDKEventBegin(PSF_EVENT_MUTEX_GIVE, 8);
 	} else {


### PR DESCRIPTION
This mutex is not enabled or available with tracerecorder. It is set to n when tracerecorder is enabled.