### PR TITLE
zephyr: do not check for thread->name being null

### DIFF
--- a/kernelports/Zephyr/trcKernelPort.c
+++ b/kernelports/Zephyr/trcKernelPort.c
@@ -306,7 +306,7 @@ void sys_trace_k_thread_create(struct k_thread *thread, size_t stack_size, int p
 	}
 
 #ifdef CONFIG_THREAD_NAME
-	if (thread->name != NULL && strlen(thread->name) > 0) {
+	if (strlen(thread->name) > 0) {
 		xTraceObjectSetName(xEntryHandle, thread->name);
 	}
 #endif


### PR DESCRIPTION
Thread name is an array, so do not check for it being null.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
