### PR TITLE
zephyr: fix C++ build

### DIFF
--- a/kernelports/Zephyr/include/tracing_tracerecorder.h
+++ b/kernelports/Zephyr/include/tracing_tracerecorder.h
@@ -13,6 +13,9 @@
 #include <zephyr/init.h>
 #include <trcRecorder.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* Legacy trace defines that are pending refactoring/removal by
  * the Zephyr team.
@@ -1255,5 +1258,9 @@ void sys_trace_syscall_exit(uint32_t id, const char *name);
 void sys_trace_idle(void);
 void sys_trace_isr_enter(void);
 void sys_trace_isr_exit(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*_TRACE_TRACERECORDER_H*/


### PR DESCRIPTION
Add missing extern "C" in in tracing_tracerecorder.h to fix linker error for C++ applications.