### PR TITLE
4.8.0.hotfix2: Use xTraceEventAddString instead of xTraceEventAddData

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "Percepio Trace Recorder"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v4.8.0.hotfix1
+PROJECT_NUMBER         = v4.8.0.hotfix2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/config/trcConfig.h
+++ b/config/trcConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/config/trcSnapshotConfig.h
+++ b/config/trcSnapshotConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/config/trcStreamingConfig.h
+++ b/config/trcStreamingConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/extras/TraceRecorderInit/TraceRecorderInit.cpp
+++ b/extras/TraceRecorderInit/TraceRecorderInit.cpp
@@ -1,5 +1,5 @@
 /*
- * Percepio Trace Recorder Initialization v4.8.0.hotfix1
+ * Percepio Trace Recorder Initialization v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/extras/TraceRecorderInit/include/TraceRecorderInit.h
+++ b/extras/TraceRecorderInit/include/TraceRecorderInit.h
@@ -1,5 +1,5 @@
 /*
- * Percepio Trace Recorder Initialization v4.8.0.hotfix1
+ * Percepio Trace Recorder Initialization v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/extras/TraceRecorderInit/readme.txt
+++ b/extras/TraceRecorderInit/readme.txt
@@ -1,4 +1,4 @@
-Percepio Trace Recorder Initialization v4.8.0.hotfix1
+Percepio Trace Recorder Initialization v4.8.0.hotfix2
 Copyright 2023 Percepio AB
 www.percepio.com
 

--- a/include/trcAssert.h
+++ b/include/trcAssert.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcCounter.h
+++ b/include/trcCounter.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcDefines.h
+++ b/include/trcDefines.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/include/trcDependency.h
+++ b/include/trcDependency.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcDiagnostics.h
+++ b/include/trcDiagnostics.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcEntryTable.h
+++ b/include/trcEntryTable.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcError.h
+++ b/include/trcError.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcEvent.h
+++ b/include/trcEvent.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcEventBuffer.h
+++ b/include/trcEventBuffer.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcExtension.h
+++ b/include/trcExtension.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcHardwarePort.h
+++ b/include/trcHardwarePort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/include/trcHeap.h
+++ b/include/trcHeap.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcISR.h
+++ b/include/trcISR.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcInternalEventBuffer.h
+++ b/include/trcInternalEventBuffer.h
@@ -1,5 +1,5 @@
 /*
- * Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/include/trcInterval.h
+++ b/include/trcInterval.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcMultiCoreEventBuffer.h
+++ b/include/trcMultiCoreEventBuffer.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcObject.h
+++ b/include/trcObject.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcPrint.h
+++ b/include/trcPrint.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcRecorder.h
+++ b/include/trcRecorder.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/include/trcRunnable.h
+++ b/include/trcRunnable.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcStackMonitor.h
+++ b/include/trcStackMonitor.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder SDK for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder SDK for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcStateMachine.h
+++ b/include/trcStateMachine.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcStaticBuffer.h
+++ b/include/trcStaticBuffer.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcString.h
+++ b/include/trcString.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcTask.h
+++ b/include/trcTask.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcTimestamp.h
+++ b/include/trcTimestamp.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcTypes.h
+++ b/include/trcTypes.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/include/trcUtility.h
+++ b/include/trcUtility.h
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/kernelports/Zephyr/config/core/trcConfig.h
+++ b/kernelports/Zephyr/config/core/trcConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/config/core/trcSnapshotConfig.h
+++ b/kernelports/Zephyr/config/core/trcSnapshotConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/config/core/trcStreamingConfig.h
+++ b/kernelports/Zephyr/config/core/trcStreamingConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/config/trcKernelPortConfig.h
+++ b/kernelports/Zephyr/config/trcKernelPortConfig.h
@@ -1,5 +1,5 @@
 ﻿/*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/config/trcKernelPortSnapshotConfig.h
+++ b/kernelports/Zephyr/config/trcKernelPortSnapshotConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/config/trcKernelPortStreamingConfig.h
+++ b/kernelports/Zephyr/config/trcKernelPortStreamingConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/include/tracing_tracerecorder.h
+++ b/kernelports/Zephyr/include/tracing_tracerecorder.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/include/trcKernelPort.h
+++ b/kernelports/Zephyr/include/trcKernelPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/scripts/tz_parse_syscalls.py
+++ b/kernelports/Zephyr/scripts/tz_parse_syscalls.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-    Trace Recorder for Tracealyzer v4.8.0.hotfix1
+    Trace Recorder for Tracealyzer v4.8.0.hotfix2
     Copyright 2023 Percepio AB
     www.percepio.com
 

--- a/kernelports/Zephyr/streamports/ARM_ITM/config/trcStreamPortConfig.h
+++ b/kernelports/Zephyr/streamports/ARM_ITM/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/streamports/Jlink_RTT/config/trcStreamPortConfig.h
+++ b/kernelports/Zephyr/streamports/Jlink_RTT/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/streamports/RingBuffer/config/trcStreamPortConfig.h
+++ b/kernelports/Zephyr/streamports/RingBuffer/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/kernelports/Zephyr/streamports/Semihost/config/trcStreamPortConfig.h
+++ b/kernelports/Zephyr/streamports/Semihost/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/streamports/Semihost/include/trcStreamPort.h
+++ b/kernelports/Zephyr/streamports/Semihost/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/streamports/Semihost/trcStreamPort.c
+++ b/kernelports/Zephyr/streamports/Semihost/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/kernelports/Zephyr/trcKernelPort.c
+++ b/kernelports/Zephyr/trcKernelPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *
@@ -1401,7 +1401,7 @@ void sys_trace_syscall_enter(uint32_t id, const char *name) {
 		xTraceEventAddUnsignedBaseType(xTraceHandle, (TraceUnsignedBaseType_t)id);
 
 		/* Add name */
-		xTraceEventAddData(xTraceHandle, (void*)name, strlen(name));
+		xTraceEventAddString(xTraceHandle, name, strlen(name));
 
 		xTraceEventEnd(xTraceHandle);
 	}

--- a/streamports/ARM_ITM/Keil-uVision-Tracealyzer-ITM-Exporter.ini
+++ b/streamports/ARM_ITM/Keil-uVision-Tracealyzer-ITM-Exporter.ini
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/ARM_ITM/config/trcStreamPortConfig.h
+++ b/streamports/ARM_ITM/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/ARM_ITM/include/trcStreamPort.h
+++ b/streamports/ARM_ITM/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/ARM_ITM/trcStreamPort.c
+++ b/streamports/ARM_ITM/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/File/config/trcStreamPortConfig.h
+++ b/streamports/File/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/File/include/trcStreamPort.h
+++ b/streamports/File/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/File/trcStreamPort.c
+++ b/streamports/File/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/Jlink_RTT/config/trcStreamPortConfig.h
+++ b/streamports/Jlink_RTT/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/Jlink_RTT/include/trcStreamPort.h
+++ b/streamports/Jlink_RTT/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/Jlink_RTT/trcStreamPort.c
+++ b/streamports/Jlink_RTT/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/RingBuffer/config/trcStreamPortConfig.h
+++ b/streamports/RingBuffer/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/streamports/RingBuffer/include/trcStreamPort.h
+++ b/streamports/RingBuffer/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/streamports/RingBuffer/trcStreamPort.c
+++ b/streamports/RingBuffer/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/streamports/STM32_USB_CDC/config/trcStreamPortConfig.h
+++ b/streamports/STM32_USB_CDC/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/STM32_USB_CDC/include/trcStreamPort.h
+++ b/streamports/STM32_USB_CDC/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/STM32_USB_CDC/trcStreamPort.c
+++ b/streamports/STM32_USB_CDC/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/TCPIP/config/trcStreamPortConfig.h
+++ b/streamports/TCPIP/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/TCPIP/include/trcStreamPort.h
+++ b/streamports/TCPIP/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/TCPIP/trcStreamPort.c
+++ b/streamports/TCPIP/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/TCPIP_Win32/config/trcStreamPortConfig.h
+++ b/streamports/TCPIP_Win32/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/TCPIP_Win32/include/trcStreamPort.h
+++ b/streamports/TCPIP_Win32/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/TCPIP_Win32/trcStreamPort.c
+++ b/streamports/TCPIP_Win32/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/UDP/config/trcStreamPortConfig.h
+++ b/streamports/UDP/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/UDP/include/trcStreamPort.h
+++ b/streamports/UDP/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/UDP/trcStreamPort.c
+++ b/streamports/UDP/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/XMOS_xScope/config/trcStreamPortConfig.h
+++ b/streamports/XMOS_xScope/config/trcStreamPortConfig.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/XMOS_xScope/include/trcStreamPort.h
+++ b/streamports/XMOS_xScope/include/trcStreamPort.h
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/streamports/XMOS_xScope/trcStreamPort.c
+++ b/streamports/XMOS_xScope/trcStreamPort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/trcAssert.c
+++ b/trcAssert.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcCounter.c
+++ b/trcCounter.c
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcDependency.c
+++ b/trcDependency.c
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcDiagnostics.c
+++ b/trcDiagnostics.c
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcEntryTable.c
+++ b/trcEntryTable.c
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcError.c
+++ b/trcError.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcEvent.c
+++ b/trcEvent.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcEventBuffer.c
+++ b/trcEventBuffer.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcExtension.c
+++ b/trcExtension.c
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcHardwarePort.c
+++ b/trcHardwarePort.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/trcHeap.c
+++ b/trcHeap.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcISR.c
+++ b/trcISR.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcInternalEventBuffer.c
+++ b/trcInternalEventBuffer.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/trcInterval.c
+++ b/trcInterval.c
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcMultiCoreEventBuffer.c
+++ b/trcMultiCoreEventBuffer.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcObject.c
+++ b/trcObject.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcPrint.c
+++ b/trcPrint.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcRunnable.c
+++ b/trcRunnable.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcSnapshotRecorder.c
+++ b/trcSnapshotRecorder.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/trcStackMonitor.c
+++ b/trcStackMonitor.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcStateMachine.c
+++ b/trcStateMachine.c
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcStaticBuffer.c
+++ b/trcStaticBuffer.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcStreamingRecorder.c
+++ b/trcStreamingRecorder.c
@@ -1,5 +1,5 @@
 /*
- * Trace Recorder for Tracealyzer v4.8.0.hotfix1
+ * Trace Recorder for Tracealyzer v4.8.0.hotfix2
  * Copyright 2023 Percepio AB
  * www.percepio.com
  *

--- a/trcString.c
+++ b/trcString.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcTask.c
+++ b/trcTask.c
@@ -1,5 +1,5 @@
 /*
-* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Percepio Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *

--- a/trcTimestamp.c
+++ b/trcTimestamp.c
@@ -1,5 +1,5 @@
 /*
-* Trace Recorder for Tracealyzer v4.8.0.hotfix1
+* Trace Recorder for Tracealyzer v4.8.0.hotfix2
 * Copyright 2023 Percepio AB
 * www.percepio.com
 *


### PR DESCRIPTION
xTraceEventAddData will add 4 bytes for every byte in the string, resulting in the end of the circular buffer being overwritten, and thus, xTraceEventAddString should be used for this purpose.